### PR TITLE
Fix theme parser error in gtk.css

### DIFF
--- a/themes/Gruvbox-Dark-B-LB/gtk-4.0/gtk-dark.css
+++ b/themes/Gruvbox-Dark-B-LB/gtk-4.0/gtk-dark.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(249, 245, 215, 0.5);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,

--- a/themes/Gruvbox-Dark-B-LB/gtk-4.0/gtk.css
+++ b/themes/Gruvbox-Dark-B-LB/gtk-4.0/gtk.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(249, 245, 215, 0.5);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,

--- a/themes/Gruvbox-Dark-B/gtk-4.0/gtk-dark.css
+++ b/themes/Gruvbox-Dark-B/gtk-4.0/gtk-dark.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(249, 245, 215, 0.5);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,

--- a/themes/Gruvbox-Dark-B/gtk-4.0/gtk.css
+++ b/themes/Gruvbox-Dark-B/gtk-4.0/gtk.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(249, 245, 215, 0.5);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,

--- a/themes/Gruvbox-Dark-BL-LB/gtk-4.0/gtk-dark.css
+++ b/themes/Gruvbox-Dark-BL-LB/gtk-4.0/gtk-dark.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(249, 245, 215, 0.5);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,

--- a/themes/Gruvbox-Dark-BL-LB/gtk-4.0/gtk.css
+++ b/themes/Gruvbox-Dark-BL-LB/gtk-4.0/gtk.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(249, 245, 215, 0.5);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,

--- a/themes/Gruvbox-Dark-BL/gtk-4.0/gtk-dark.css
+++ b/themes/Gruvbox-Dark-BL/gtk-4.0/gtk-dark.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(249, 245, 215, 0.5);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,

--- a/themes/Gruvbox-Dark-BL/gtk-4.0/gtk.css
+++ b/themes/Gruvbox-Dark-BL/gtk-4.0/gtk.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(249, 245, 215, 0.5);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,

--- a/themes/Gruvbox-Light-B-LB/gtk-4.0/gtk-dark.css
+++ b/themes/Gruvbox-Light-B-LB/gtk-4.0/gtk-dark.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(0, 0, 0, 0.38);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,
@@ -7051,4 +7051,3 @@ indicatorbin.needs-attention > indicator {
 indicatorbin.needs-attention > indicator > label {
   color: #f9f5d7;
 }
-

--- a/themes/Gruvbox-Light-B-LB/gtk-4.0/gtk.css
+++ b/themes/Gruvbox-Light-B-LB/gtk-4.0/gtk.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(0, 0, 0, 0.38);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,

--- a/themes/Gruvbox-Light-B/gtk-4.0/gtk-dark.css
+++ b/themes/Gruvbox-Light-B/gtk-4.0/gtk-dark.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(0, 0, 0, 0.38);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,
@@ -7116,4 +7116,3 @@ indicatorbin.needs-attention > indicator {
 indicatorbin.needs-attention > indicator > label {
   color: #f9f5d7;
 }
-

--- a/themes/Gruvbox-Light-B/gtk-4.0/gtk.css
+++ b/themes/Gruvbox-Light-B/gtk-4.0/gtk.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(0, 0, 0, 0.38);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,

--- a/themes/Gruvbox-Light-BL-LB/gtk-4.0/gtk-dark.css
+++ b/themes/Gruvbox-Light-BL-LB/gtk-4.0/gtk-dark.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(0, 0, 0, 0.38);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,
@@ -7112,4 +7112,3 @@ indicatorbin.needs-attention > indicator {
 indicatorbin.needs-attention > indicator > label {
   color: #f9f5d7;
 }
-

--- a/themes/Gruvbox-Light-BL-LB/gtk-4.0/gtk.css
+++ b/themes/Gruvbox-Light-BL-LB/gtk-4.0/gtk.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(0, 0, 0, 0.38);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,

--- a/themes/Gruvbox-Light-BL/gtk-4.0/gtk-dark.css
+++ b/themes/Gruvbox-Light-BL/gtk-4.0/gtk-dark.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(0, 0, 0, 0.38);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,
@@ -7112,4 +7112,3 @@ indicatorbin.needs-attention > indicator {
 indicatorbin.needs-attention > indicator > label {
   color: #f9f5d7;
 }
-

--- a/themes/Gruvbox-Light-BL/gtk-4.0/gtk.css
+++ b/themes/Gruvbox-Light-BL/gtk-4.0/gtk.css
@@ -248,7 +248,7 @@ label.separator {
 label:disabled {
   color: rgba(0, 0, 0, 0.38);
   opacity: 1;
-  filter: 0;
+  filter: none;
 }
 
 headerbar label:disabled,


### PR DESCRIPTION
When I load the GTK4 component of the theme by symlinking `~/.themes/Gruvbox-Dark-BL/gtk-4.0` in `~/.config` I noticed that some GNOME apps would have messages like these logged in `journalctl` many times per second:

```
Nov 26 23:27:48 fadi-surface gnome-software[8023]: Theme parser error: gtk.css:251:11-12: Expected a filter
Nov 26 23:27:48 fadi-surface xdg-desktop-por[8495]: Theme parser error: gtk.css:251:11-12: Expected a filter
Nov 26 23:27:48 fadi-surface gnome-software[5448]: Theme parser error: gtk.css:251:11-12: Expected a filter
Nov 26 23:27:48 fadi-surface nautilus[7935]: Theme parser error: gtk.css:251:11-12: Expected a filter
```

The culprit here seems to be that the `filter` CSS attribute only accepts a filter effect and not an integer. Changing it from `0` to `none` fixes the issue.