### PR TITLE
Fix quick settings gnome 44

### DIFF
--- a/themes/Gruvbox-Dark-B-LB/gnome-shell/gnome-shell.css
+++ b/themes/Gruvbox-Dark-B-LB/gnome-shell/gnome-shell.css
@@ -2911,18 +2911,32 @@ StEntry StLabel.hint-text,
   icon-size: 16px !important;
 }
 
-.quick-menu-toggle:ltr > StBoxLayout {
-  padding-right: 0;
+.quick-menu-toggle .quick-toggle {
+  min-width: auto;
+  max-width: auto;
 }
 
-.quick-menu-toggle:rtl > StBoxLayout {
-  padding-left: 0;
+.quick-menu-toggle .quick-toggle:ltr {
+  border-radius: 6px 0 0 6px;
+}
+
+.quick-menu-toggle .quick-toggle:ltr > StBoxLayout {
+  padding-right: 9px;
+}
+
+.quick-menu-toggle .quick-toggle:rtl {
+  border-radius: 0 6px 6px 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtl > StBoxLayout {
+  padding-left: 9px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow {
   background-color: rgba(249, 245, 215, 0.08) !important;
   padding: 6px 10.5px;
   icon-size: 16px !important;
+  border: 1px solid rgba(249, 245, 215, 0.2);
 }
 
 .quick-menu-toggle .quick-toggle-arrow:active {
@@ -2931,10 +2945,12 @@ StEntry StLabel.hint-text,
 
 .quick-menu-toggle .quick-toggle-arrow:ltr {
   border-radius: 0 6px 6px 0;
+  border-left-width: 0px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow:rtl {
   border-radius: 6px 0 0 6px;
+  border-right-width: 0px;
 }
 
 .quick-slider {

--- a/themes/Gruvbox-Dark-B/gnome-shell/gnome-shell.css
+++ b/themes/Gruvbox-Dark-B/gnome-shell/gnome-shell.css
@@ -2911,18 +2911,9 @@ StEntry StLabel.hint-text,
   icon-size: 16px !important;
 }
 
-/* .quick-menu-toggle:ltr > StBoxLayout {
-  padding-right: 0;
-}
-
-.quick-menu-toggle:rtl > StBoxLayout {
-  padding-left: 0;
-} */
-
 .quick-menu-toggle .quick-toggle {
   min-width: auto;
   max-width: auto;
-
 }
 
 .quick-menu-toggle .quick-toggle:ltr {

--- a/themes/Gruvbox-Dark-B/gnome-shell/gnome-shell.css
+++ b/themes/Gruvbox-Dark-B/gnome-shell/gnome-shell.css
@@ -2911,18 +2911,41 @@ StEntry StLabel.hint-text,
   icon-size: 16px !important;
 }
 
-.quick-menu-toggle:ltr > StBoxLayout {
+/* .quick-menu-toggle:ltr > StBoxLayout {
   padding-right: 0;
 }
 
 .quick-menu-toggle:rtl > StBoxLayout {
   padding-left: 0;
+} */
+
+.quick-menu-toggle .quick-toggle {
+  min-width: auto;
+  max-width: auto;
+
+}
+
+.quick-menu-toggle .quick-toggle:ltr {
+  border-radius: 6px 0 0 6px;
+}
+
+.quick-menu-toggle .quick-toggle:ltr > StBoxLayout {
+  padding-right: 9px;
+}
+
+.quick-menu-toggle .quick-toggle:rtl {
+  border-radius: 0 6px 6px 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtl > StBoxLayout {
+  padding-left: 9px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow {
   background-color: rgba(249, 245, 215, 0.08) !important;
   padding: 6px 10.5px;
   icon-size: 16px !important;
+  border: 1px solid rgba(249, 245, 215, 0.2);
 }
 
 .quick-menu-toggle .quick-toggle-arrow:active {
@@ -2931,10 +2954,12 @@ StEntry StLabel.hint-text,
 
 .quick-menu-toggle .quick-toggle-arrow:ltr {
   border-radius: 0 6px 6px 0;
+  border-left-width: 0px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow:rtl {
   border-radius: 6px 0 0 6px;
+  border-right-width: 0px;
 }
 
 .quick-slider {

--- a/themes/Gruvbox-Dark-BL-LB/gnome-shell/gnome-shell.css
+++ b/themes/Gruvbox-Dark-BL-LB/gnome-shell/gnome-shell.css
@@ -2897,18 +2897,32 @@ StEntry StLabel.hint-text,
   icon-size: 16px !important;
 }
 
-.quick-menu-toggle:ltr > StBoxLayout {
-  padding-right: 0;
+.quick-menu-toggle .quick-toggle {
+  min-width: auto;
+  max-width: auto;
 }
 
-.quick-menu-toggle:rtl > StBoxLayout {
-  padding-left: 0;
+.quick-menu-toggle .quick-toggle:ltr {
+  border-radius: 6px 0 0 6px;
+}
+
+.quick-menu-toggle .quick-toggle:ltr > StBoxLayout {
+  padding-right: 9px;
+}
+
+.quick-menu-toggle .quick-toggle:rtl {
+  border-radius: 0 6px 6px 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtl > StBoxLayout {
+  padding-left: 9px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow {
   background-color: rgba(249, 245, 215, 0.08) !important;
   padding: 6px 10.5px;
   icon-size: 16px !important;
+  border: 1px solid rgba(249, 245, 215, 0.2);
 }
 
 .quick-menu-toggle .quick-toggle-arrow:active {
@@ -2917,10 +2931,12 @@ StEntry StLabel.hint-text,
 
 .quick-menu-toggle .quick-toggle-arrow:ltr {
   border-radius: 0 6px 6px 0;
+  border-left-width: 0px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow:rtl {
   border-radius: 6px 0 0 6px;
+  border-right-width: 0px;
 }
 
 .quick-slider {

--- a/themes/Gruvbox-Dark-BL/gnome-shell/gnome-shell.css
+++ b/themes/Gruvbox-Dark-BL/gnome-shell/gnome-shell.css
@@ -2897,18 +2897,32 @@ StEntry StLabel.hint-text,
   icon-size: 16px !important;
 }
 
-.quick-menu-toggle:ltr > StBoxLayout {
-  padding-right: 0;
+.quick-menu-toggle .quick-toggle {
+  min-width: auto;
+  max-width: auto;
 }
 
-.quick-menu-toggle:rtl > StBoxLayout {
-  padding-left: 0;
+.quick-menu-toggle .quick-toggle:ltr {
+  border-radius: 6px 0 0 6px;
+}
+
+.quick-menu-toggle .quick-toggle:ltr > StBoxLayout {
+  padding-right: 9px;
+}
+
+.quick-menu-toggle .quick-toggle:rtl {
+  border-radius: 0 6px 6px 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtl > StBoxLayout {
+  padding-left: 9px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow {
   background-color: rgba(249, 245, 215, 0.08) !important;
   padding: 6px 10.5px;
   icon-size: 16px !important;
+  border: 1px solid rgba(249, 245, 215, 0.2);
 }
 
 .quick-menu-toggle .quick-toggle-arrow:active {
@@ -2917,10 +2931,12 @@ StEntry StLabel.hint-text,
 
 .quick-menu-toggle .quick-toggle-arrow:ltr {
   border-radius: 0 6px 6px 0;
+  border-left-width: 0px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow:rtl {
   border-radius: 6px 0 0 6px;
+  border-right-width: 0px;
 }
 
 .quick-slider {

--- a/themes/Gruvbox-Light-B-LB/gnome-shell/gnome-shell.css
+++ b/themes/Gruvbox-Light-B-LB/gnome-shell/gnome-shell.css
@@ -2907,18 +2907,32 @@ StEntry StLabel.hint-text,
   icon-size: 16px !important;
 }
 
-.quick-menu-toggle:ltr > StBoxLayout {
-  padding-right: 0;
+.quick-menu-toggle .quick-toggle {
+  min-width: auto;
+  max-width: auto;
 }
 
-.quick-menu-toggle:rtl > StBoxLayout {
-  padding-left: 0;
+.quick-menu-toggle .quick-toggle:ltr {
+  border-radius: 6px 0 0 6px;
+}
+
+.quick-menu-toggle .quick-toggle:ltr > StBoxLayout {
+  padding-right: 9px;
+}
+
+.quick-menu-toggle .quick-toggle:rtl {
+  border-radius: 0 6px 6px 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtl > StBoxLayout {
+  padding-left: 9px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow {
   background-color: rgba(0, 0, 0, 0.04) !important;
   padding: 6px 10.5px;
   icon-size: 16px !important;
+  border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 .quick-menu-toggle .quick-toggle-arrow:active {
@@ -2927,10 +2941,12 @@ StEntry StLabel.hint-text,
 
 .quick-menu-toggle .quick-toggle-arrow:ltr {
   border-radius: 0 6px 6px 0;
+  border-left-width: 0px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow:rtl {
   border-radius: 6px 0 0 6px;
+  border-right-width: 0px;
 }
 
 .quick-slider {

--- a/themes/Gruvbox-Light-B/gnome-shell/gnome-shell.css
+++ b/themes/Gruvbox-Light-B/gnome-shell/gnome-shell.css
@@ -2906,18 +2906,32 @@ StEntry StLabel.hint-text,
   icon-size: 16px !important;
 }
 
-.quick-menu-toggle:ltr > StBoxLayout {
-  padding-right: 0;
+.quick-menu-toggle .quick-toggle {
+  min-width: auto;
+  max-width: auto;
 }
 
-.quick-menu-toggle:rtl > StBoxLayout {
-  padding-left: 0;
+.quick-menu-toggle .quick-toggle:ltr {
+  border-radius: 6px 0 0 6px;
+}
+
+.quick-menu-toggle .quick-toggle:ltr > StBoxLayout {
+  padding-right: 9px;
+}
+
+.quick-menu-toggle .quick-toggle:rtl {
+  border-radius: 0 6px 6px 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtl > StBoxLayout {
+  padding-left: 9px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow {
   background-color: rgba(0, 0, 0, 0.04) !important;
   padding: 6px 10.5px;
   icon-size: 16px !important;
+  border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 .quick-menu-toggle .quick-toggle-arrow:active {
@@ -2926,10 +2940,12 @@ StEntry StLabel.hint-text,
 
 .quick-menu-toggle .quick-toggle-arrow:ltr {
   border-radius: 0 6px 6px 0;
+  border-left-width: 0px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow:rtl {
   border-radius: 6px 0 0 6px;
+  border-right-width: 0px;
 }
 
 .quick-slider {

--- a/themes/Gruvbox-Light-BL-LB/gnome-shell/gnome-shell.css
+++ b/themes/Gruvbox-Light-BL-LB/gnome-shell/gnome-shell.css
@@ -2905,18 +2905,32 @@ StEntry StLabel.hint-text,
   icon-size: 16px !important;
 }
 
-.quick-menu-toggle:ltr > StBoxLayout {
-  padding-right: 0;
+.quick-menu-toggle .quick-toggle {
+  min-width: auto;
+  max-width: auto;
 }
 
-.quick-menu-toggle:rtl > StBoxLayout {
-  padding-left: 0;
+.quick-menu-toggle .quick-toggle:ltr {
+  border-radius: 6px 0 0 6px;
+}
+
+.quick-menu-toggle .quick-toggle:ltr > StBoxLayout {
+  padding-right: 9px;
+}
+
+.quick-menu-toggle .quick-toggle:rtl {
+  border-radius: 0 6px 6px 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtl > StBoxLayout {
+  padding-left: 9px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow {
   background-color: rgba(0, 0, 0, 0.04) !important;
   padding: 6px 10.5px;
   icon-size: 16px !important;
+  border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 .quick-menu-toggle .quick-toggle-arrow:active {
@@ -2925,10 +2939,12 @@ StEntry StLabel.hint-text,
 
 .quick-menu-toggle .quick-toggle-arrow:ltr {
   border-radius: 0 6px 6px 0;
+  border-left-width: 0px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow:rtl {
   border-radius: 6px 0 0 6px;
+  border-right-width: 0px;
 }
 
 .quick-slider {

--- a/themes/Gruvbox-Light-BL/gnome-shell/gnome-shell.css
+++ b/themes/Gruvbox-Light-BL/gnome-shell/gnome-shell.css
@@ -2905,18 +2905,32 @@ StEntry StLabel.hint-text,
   icon-size: 16px !important;
 }
 
-.quick-menu-toggle:ltr > StBoxLayout {
-  padding-right: 0;
+.quick-menu-toggle .quick-toggle {
+  min-width: auto;
+  max-width: auto;
 }
 
-.quick-menu-toggle:rtl > StBoxLayout {
-  padding-left: 0;
+.quick-menu-toggle .quick-toggle:ltr {
+  border-radius: 6px 0 0 6px;
+}
+
+.quick-menu-toggle .quick-toggle:ltr > StBoxLayout {
+  padding-right: 9px;
+}
+
+.quick-menu-toggle .quick-toggle:rtl {
+  border-radius: 0 6px 6px 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtl > StBoxLayout {
+  padding-left: 9px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow {
   background-color: rgba(0, 0, 0, 0.04) !important;
   padding: 6px 10.5px;
   icon-size: 16px !important;
+  border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 .quick-menu-toggle .quick-toggle-arrow:active {
@@ -2925,10 +2939,12 @@ StEntry StLabel.hint-text,
 
 .quick-menu-toggle .quick-toggle-arrow:ltr {
   border-radius: 0 6px 6px 0;
+  border-left-width: 0px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow:rtl {
   border-radius: 6px 0 0 6px;
+  border-right-width: 0px;
 }
 
 .quick-slider {


### PR DESCRIPTION
Fix the quick settings ui bug in gnome 44 update

Fixes issue #37 

Gnome 44 code reference: https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/data/theme/gnome-shell-sass/widgets/_quick-settings.scss


The look now:

![image](https://github.com/Fausto-Korpsvart/Gruvbox-GTK-Theme/assets/75582834/765db7ac-fef2-4708-a3d0-4dcacd51a5a3)
