### PR TITLE
Fix #43 invalid name of pseudo-class

### DIFF
--- a/themes/Gruvbox-Dark-B-LB/gtk-3.0/gtk.css
+++ b/themes/Gruvbox-Dark-B-LB/gtk-3.0/gtk.css
@@ -6625,14 +6625,10 @@ popover.emoji-completion .emoji:hover {
 
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):last-child:dir(
-    ltr
-  ):disabled,
+  button:not(.suggested-action):not(.destructive-action):last-child:dir(ltr):disabled,
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):first-child:dir(
-    rtl
-  ):disabled {
+  button:not(.suggested-action):not(.destructive-action):first-child:dir(rtl):disabled {
   color: #89b482;
   background-color: #282828;
 }

--- a/themes/Gruvbox-Dark-B/gtk-3.0/gtk.css
+++ b/themes/Gruvbox-Dark-B/gtk-3.0/gtk.css
@@ -6700,14 +6700,10 @@ popover.emoji-completion .emoji:hover {
 
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):last-child:dir(
-    ltr
-  ):disabled,
+  button:not(.suggested-action):not(.destructive-action):last-child:dir(ltr):disabled,
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):first-child:dir(
-    rtl
-  ):disabled {
+  button:not(.suggested-action):not(.destructive-action):first-child:dir(rtl):disabled {
   color: #89b482;
   background-color: #282828;
 }

--- a/themes/Gruvbox-Dark-BL-LB/gtk-3.0/gtk.css
+++ b/themes/Gruvbox-Dark-BL-LB/gtk-3.0/gtk.css
@@ -6613,14 +6613,10 @@ popover.emoji-completion .emoji:hover {
 
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):last-child:dir(
-    ltr
-  ):disabled,
+  button:not(.suggested-action):not(.destructive-action):last-child:dir(ltr):disabled,
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):first-child:dir(
-    rtl
-  ):disabled {
+  button:not(.suggested-action):not(.destructive-action):first-child:dir(rtl):disabled {
   color: #89b482;
   background-color: #282828;
 }

--- a/themes/Gruvbox-Dark-BL/gtk-3.0/gtk.css
+++ b/themes/Gruvbox-Dark-BL/gtk-3.0/gtk.css
@@ -6688,14 +6688,10 @@ popover.emoji-completion .emoji:hover {
 
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):last-child:dir(
-    ltr
-  ):disabled,
+  button:not(.suggested-action):not(.destructive-action):last-child:dir(ltr):disabled,
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):first-child:dir(
-    rtl
-  ):disabled {
+  button:not(.suggested-action):not(.destructive-action):first-child:dir(rtl):disabled {
   color: #89b482;
   background-color: #282828;
 }


### PR DESCRIPTION
The warning is related to gtk-3.0 themes files.
In two occurrences, the `:run` pseudo-class having its argument placed on a separate line, and this triggers the warning.

This PR fixes #43.