### PR TITLE
chore: create issue template to improve issues structures

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+## Description
+
+Please describe the issue you're encountering in as much detail as possible.
+
+## Version
+
+Which version of the Gruvbox GTK theme are you using?  
+Example: v1.5.0 or latest commit
+
+## Operating System
+
+Which Linux distribution are you using?  
+Example: Ubuntu 22.04, Fedora 39
+
+## Desktop Environment
+
+Which desktop environment are you using?  
+Example: GNOME 45, KDE Plasma 6.0, XFCE 4.18
+
+## Theme Variant
+
+Which Gruvbox variant are you using?  
+Example: Gruvbox-Dark, Gruvbox-Light, Gruvbox-Material, etc.
+
+## Steps to Reproduce
+
+Please list the steps to reproduce the issue:
+
+1. Install the theme
+2. Set it in GNOME Tweaks or your desktop environment settings
+3. Open an application or interface
+4. See the issue
+
+## Expected behavior
+
+What did you expect to happen?
+
+## Screenshots
+
+If applicable, please add screenshots that demonstrate the issue.
+
+## Logs
+
+If you have any error logs or terminal output, please paste them here.
+
+## Checklist
+
+- [ ] I have checked if the issue already exists in the repository.
+- [ ] I have provided all the necessary information for troubleshooting.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ Example: GNOME 45, KDE Plasma 6.0, XFCE 4.18
 ## Theme Variant
 
 Which Gruvbox variant are you using?  
-Example: Gruvbox-Dark, Gruvbox-Light, Gruvbox-Material, etc.
+Example: Gruvbox-Dark, Gruvbox-Light, etc.
 
 ## Steps to Reproduce
 


### PR DESCRIPTION
I’ve added a detailed issue template to the Gruvbox GTK theme repository. This template helps users to clearly report bugs or problems by requesting essential information, such as the theme version, operating system, desktop environment, and steps to reproduce the issue. Additionally, users are prompted to provide screenshots or logs where applicable, improving the quality of the reports.

The idea is to create a more structured approach to issue reporting, making it easier for both users and maintainers to track, understand, and resolve issues effectively.