### PR TITLE
fix: move [Desktop Entry] before Type in index.theme generation

### DIFF
--- a/themes/install.sh
+++ b/themes/install.sh
@@ -104,8 +104,8 @@ install() {
     mkdir -p "${THEME_DIR}"
 
     # Index Theme File
-    echo "Type=X-GNOME-Metatheme" >>"${THEME_DIR}/index.theme"
     echo "[Desktop Entry]" >>"${THEME_DIR}/index.theme"
+    echo "Type=X-GNOME-Metatheme" >>"${THEME_DIR}/index.theme"
     echo "Name=${2}${3}${4}${5}${6}" >>"${THEME_DIR}/index.theme"
     echo "Comment=An Flat Gtk+ theme based on Elegant Design" >>"${THEME_DIR}/index.theme"
     echo "Encoding=UTF-8" >>"${THEME_DIR}/index.theme"


### PR DESCRIPTION
## Summary

This PR fixes the generated index.theme layout so Desktop Entry keys are written in a valid INI order.

## Problem

The installer wrote:

Type=X-GNOME-Metatheme
[Desktop Entry]
Name=Gruvbox-Dark
...

That places Type outside any section.

The Desktop Entry spec requires keys to appear inside a section, so parsers that follow the spec can ignore the orphaned Type key.

## Why this matters

When Type is ignored, metadata in index.theme becomes incomplete or unreliable for tooling that expects a valid Desktop Entry block.

Practical impact can include:
- Theme metadata not being recognized consistently by strict parsers.
- Theme discovery or validation tools reporting the file as malformed.
- Inconsistent behavior across environments depending on parser tolerance.

## Fix

Write [Desktop Entry] first, then write Type and the remaining keys.

## Result

Generated index.theme is now valid and parser-friendly:

[Desktop Entry]
Type=X-GNOME-Metatheme
Name=Gruvbox-Dark
...
